### PR TITLE
rubocopの設定の変更とインデント数の変更

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -6,3 +6,22 @@ inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
 # Layout/SpaceInsideArrayLiteralBrackets:
 #   Enabled: false
+
+# インデント設定
+Layout/IndentationWidth:
+  Width: 2
+
+Layout/FirstHashElementIndentation:
+  IndentationWidth: 2
+
+Layout/FirstArrayElementIndentation:
+  IndentationWidth: 2
+
+Layout/AssignmentIndentation:
+  IndentationWidth: 2
+
+Layout/FirstArgumentIndentation:
+  IndentationWidth: 2
+
+Layout/FirstParameterIndentation:
+  IndentationWidth: 2

--- a/backend/app/controllers/api/sessions_controller.rb
+++ b/backend/app/controllers/api/sessions_controller.rb
@@ -14,11 +14,11 @@ class Api::SessionsController < ApplicationController
 
   def guest_login
     # テストユーザー1でゲストログイン
-    guest_user = User.find_by(email: 'test1@example.com')
-    
+    guest_user = User.find_by(email: "test1@example.com")
+
     if guest_user
       token = encode_token(user_id: guest_user.id)
-      render json: { 
+      render json: {
         token: token,
         message: "ゲストユーザーとしてログインしました"
       }, status: :ok


### PR DESCRIPTION
# 変更点

1. rubocopのルール設定としてインデント数を2つにするように変更
2. backend群のファイルのインデント数をRubyの慣習に従い2つに変更
3. rubocopのスタイリングルールをコードに適用