### PR TITLE
AWSデプロイ用の設定ファイルの作成

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,29 @@
+version: '3.8'
+
+services:
+  # Rails APIサービス
+  api:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    command: bundle exec puma -C config/puma.rb
+    environment:
+      RAILS_ENV: ${RAILS_ENV}
+      RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT}
+      DB_NAME: ${DB_NAME}
+      GMAIL_USERNAME: ${GMAIL_USERNAME}
+      GMAIL_PASSWORD: ${GMAIL_PASSWORD}
+
+  # Nginx (Webサーバー)
+  nginx:
+    build:
+      context: .
+      dockerfile: ./nginx/Dockerfile
+    ports:
+      - "80:80"
+    depends_on:
+      - api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,10 +41,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_ROOT_HOST: '%'
-      MYSQL_DEFAULT_AUTHENTICATION_PLUGIN: mysql_native_password
     volumes:
       - db-data-v2:/var/lib/mysql
-      - ./mysql-config.cnf:/etc/mysql/conf.d/custom.cnf
     ports:
       - "3306:3306"
     healthcheck:

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,0 +1,14 @@
+
+FROM node:24.5.0-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+COPY . .
+
+RUN yarn build
+
+
+FROM scratch

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,24 @@
+
+FROM node:24.5.0-alpine AS react-builder
+
+WORKDIR /app
+
+COPY ./frontend/package.json ./frontend/yarn.lock ./
+WORKDIR /app/frontend
+RUN yarn install --frozen-lockfile
+
+WORKDIR /app
+COPY ./frontend ./
+
+WORKDIR /app/frontend
+RUN yarn build
+
+FROM nginx:1.25-alpine
+
+COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
+
+COPY --from=react-builder /app/frontend/build /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/deafault.conf
+++ b/nginx/deafault.conf
@@ -1,0 +1,26 @@
+
+upstream api {
+  server api:3000;
+}
+
+server {
+  listen 80;
+  server_name yubikirigennmann.com;
+
+  # ドキュメントルート（Reactの静的ファイルがある場所）
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # /api/ から始まるリクエストは全てPuma(Rails)に転送
+  location /api {
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_pass http://api;
+  }
+
+  # それ以外のリクエストはReactが処理
+  location / {
+    try_files $uri /index.html;
+  }
+}


### PR DESCRIPTION
# 概要
開発環境のインフラストラクチャ改善とスタイルツールの統一化を実施しました。
# 主な変更内容
1. Docker Compose設定の最適化
mysql-config.cnfファイルの参照を削除（ファイルが削除済みのため）
MySQL 8.4で非推奨のmysql_native_password設定を削除
コンテナ起動エラーの解決
2. スタイルツールの実行
78ファイルすべてでスタイル違反を解消
3. 本番環境のファイルを作成
AWS上にデプロイするために以下のファイル・ディレクトリを作成
docker-compose.prod.yml　.envをルートディレクトリに作成
frontendディレクトリにDockerfile.prodファイルの作成
ルートディレクトリにnginxディレクトリを作成し、その中に
deafault.conf Dockerfileの二つのファイルを作成
# 検証結果
フロントエンド: ESLint・Prettier共にエラーなし
バックエンド: RuboCopで78ファイル検査、違反事項なし
Docker: 全コンテナが正常に起動