### PR TITLE
Dockerfileの変更

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -15,7 +15,7 @@ FROM nginx:1.25-alpine
 
 COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
     
-COPY --from=react-builder /app/build /usr/share/nginx/html
+COPY --from=react-builder /app/dist /usr/share/nginx/html
 
 EXPOSE 80
     


### PR DESCRIPTION
#2  概要
Viteのビルド出力がdistなのに、/app/buildをコピーしているため
EC2上でビルドをした際に参照ができずにエラーが出てしまう。
# 変更内容
nginx内のDockerfileの該当部分のコードを
buildからdistに変更。