### PR TITLE
デプロイエラーの修正

### DIFF
--- a/backend/config/database.yml
+++ b/backend/config/database.yml
@@ -2,13 +2,13 @@ default: &default
   adapter: mysql2
   encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: root
-  password: <%= ENV['MYSQL_ROOT_PASSWORD'] %>
-  host: <%= ENV['DB_HOST'] %>
 
 development:
   <<: *default
   database: myapp_development
+  username: root
+  password: <%= ENV['MYSQL_ROOT_PASSWORD'] %>
+  host: db
 
 test:
   <<: *default


### PR DESCRIPTION
# 概要
AWSでDBに接続する際にデフォルトの環境変数の設定によって
本番用の環境変数の設置を上書きしてしまっていた。
# 変更内容
backend/config/database.yml内の
defaultの設定を最低限の共通のものだけに変更。
開発環境と本番環境のDBやユーザー名などは
個別で設定するように変更。