### PR TITLE
CORSへの対応

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_API_URL=/api

--- a/frontend/src/components/AddPromiseModal.tsx
+++ b/frontend/src/components/AddPromiseModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 
 interface AddPromiseModalProps {
   isOpen: boolean;
@@ -38,7 +39,7 @@ const AddPromiseModal = ({
         promise_id: null,
       };
 
-      await axios.post('http://localhost:3001/api/promises', {
+      await axios.post(`${API_BASE_URL}/promises`, {
         promise: promiseData,
       });
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 import Sidebar from './Sidebar';
 import PromiseColumn from './PromiseColumn';
 import AddPromiseModal from './AddPromiseModal';
@@ -29,7 +30,7 @@ const Dashboard = () => {
   const fetchPromises = useCallback(async (): Promise<void> => {
     if (!token) return;
     try {
-      const response = await axios.get('http://localhost:3001/api/promises');
+      const response = await axios.get(`${API_BASE_URL}/promises`);
       setPromises(response.data);
     } catch (error) {
       console.error('約束の取得に失敗しました:', error);
@@ -62,7 +63,7 @@ const Dashboard = () => {
     }
 
     try {
-      await axios.delete(`http://localhost:3001/api/promises/${promise.id}`);
+      await axios.delete(`${API_BASE_URL}/promises/${promise.id}`);
       await fetchPromises();
     } catch (error) {
       console.error('約束の削除に失敗しました:', error);
@@ -79,9 +80,7 @@ const Dashboard = () => {
 
     setIsSendingEmail(true);
     try {
-      const response = await axios.post(
-        'http://localhost:3001/api/evaluation_emails'
-      );
+      const response = await axios.post(`${API_BASE_URL}/evaluation_emails`);
       alert('評価メールを送信しました！');
       console.log('送信結果:', response.data);
     } catch (error) {
@@ -120,7 +119,7 @@ const Dashboard = () => {
   const handleSendDueDateEvaluations = async (): Promise<void> => {
     try {
       const response = await axios.post(
-        'http://localhost:3001/api/scheduled_tasks/send_due_date_evaluations'
+        `${API_BASE_URL}/scheduled_tasks/send_due_date_evaluations`
       );
       alert('期日が来た約束の評価メールを送信しました！');
       console.log('送信結果:', response.data);
@@ -133,7 +132,7 @@ const Dashboard = () => {
   const handleSendWeeklyEvaluations = async (): Promise<void> => {
     try {
       const response = await axios.post(
-        'http://localhost:3001/api/scheduled_tasks/send_weekly_our_promises_evaluation'
+        `${API_BASE_URL}/scheduled_tasks/send_weekly_our_promises_evaluation`
       );
       alert('毎週の二人の約束評価メールを送信しました！');
       console.log('送信結果:', response.data);

--- a/frontend/src/components/DissolvePartnershipModal.tsx
+++ b/frontend/src/components/DissolvePartnershipModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import axios from 'axios';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 import { useAuth } from '../contexts/useAuth';
 
 interface DissolvePartnershipModalProps {
@@ -26,7 +27,7 @@ const DissolvePartnershipModal = ({
     setIsDissolving(true);
 
     try {
-      await axios.delete('http://localhost:3001/api/partnerships/dissolve', {
+      await axios.delete(`${API_BASE_URL}/partnerships/dissolve`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },

--- a/frontend/src/components/EditPromiseModal.tsx
+++ b/frontend/src/components/EditPromiseModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 import type { PromiseItem } from '../types';
 
 interface EditPromiseModalProps {
@@ -30,7 +31,7 @@ const EditPromiseModal = ({
     if (!promise) return;
 
     try {
-      await axios.put(`http://localhost:3001/api/promises/${promise.id}`, {
+      await axios.put(`${API_BASE_URL}/promises/${promise.id}`, {
         promise: {
           content: content,
           due_date: dueDate || null,

--- a/frontend/src/components/EvaluationModal.tsx
+++ b/frontend/src/components/EvaluationModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 import type { PromiseItem } from '../types';
 
 interface EvaluationModalProps {
@@ -33,7 +34,7 @@ const EvaluationModal = ({
 
     try {
       await axios.post(
-        `http://localhost:3001/api/promises/${promise.id}/promise_evaluations`,
+        `${API_BASE_URL}/promises/${promise.id}/promise_evaluations`,
         {
           evaluation: {
             rating: rating,

--- a/frontend/src/components/EvaluationPage.tsx
+++ b/frontend/src/components/EvaluationPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import axios from 'axios';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 import EvaluationModal from './EvaluationModal';
 import type { PromiseItem } from '../types';
 
@@ -23,7 +24,7 @@ const EvaluationPage = () => {
     const fetchPromise = async (): Promise<void> => {
       try {
         const response = await axios.get(
-          `http://localhost:3001/api/evaluation_pages/${id}?token=${token}`
+          `${API_BASE_URL}/evaluation_pages/${id}?token=${token}`
         );
 
         if (response.data.valid_token) {

--- a/frontend/src/components/InviteAcceptPage.tsx
+++ b/frontend/src/components/InviteAcceptPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 import LoginForm from './LoginForm';
 import RegisterForm from './RegisterForm';
 
@@ -21,7 +22,7 @@ const InviteAcceptPage = () => {
       }
 
       try {
-        await axios.get(`http://localhost:3001/api/invite/${token}`);
+        await axios.get(`${API_BASE_URL}/invite/${token}`);
       } catch (error) {
         console.error('招待確認エラー:', error);
         if (axios.isAxiosError(error) && error.response) {
@@ -42,7 +43,7 @@ const InviteAcceptPage = () => {
 
     try {
       const response = await axios.get(
-        `http://localhost:3001/api/invite/${token}`
+        `${API_BASE_URL}/invite/${token}`
       );
       if (response.data.message === 'パートナーシップが作成されました') {
         alert('パートナーシップが作成されました！');

--- a/frontend/src/components/InvitePartnerPage.tsx
+++ b/frontend/src/components/InvitePartnerPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 import { useAuth } from '../contexts/useAuth';
 
 const InvitePartnerPage = () => {
@@ -25,7 +26,7 @@ const InvitePartnerPage = () => {
 
     try {
       const response = await axios.post(
-        'http://localhost:3001/api/invitations',
+        `${API_BASE_URL}/invitations`,
         {},
         {
           headers: {

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import axios from 'axios';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 import { useAuth } from '../contexts/useAuth';
 import RegisterForm from './RegisterForm';
 
@@ -25,7 +26,7 @@ const LoginForm = ({ invitationToken, onAuthSuccess }: LoginFormProps) => {
     setError('');
 
     try {
-      const response = await axios.post('http://localhost:3001/api/login', {
+      const response = await axios.post(`${API_BASE_URL}/login`, {
         email,
         password,
       });
@@ -52,9 +53,7 @@ const LoginForm = ({ invitationToken, onAuthSuccess }: LoginFormProps) => {
     setIsGuestLoggingIn(true);
 
     try {
-      const response = await axios.post(
-        'http://localhost:3001/api/guest_login'
-      );
+      const response = await axios.post(`${API_BASE_URL}/guest_login`);
       setToken(response.data.token);
 
       if (invitationToken && onAuthSuccess) {

--- a/frontend/src/components/PastEvaluationsPage.tsx
+++ b/frontend/src/components/PastEvaluationsPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 import Sidebar from './Sidebar';
 import PromiseColumn from './PromiseColumn';
 import type { EvaluatedPromise } from '../types';
@@ -16,9 +17,7 @@ const PastEvaluationsPage = () => {
     if (!token) return;
     try {
       setLoading(true);
-      const response = await axios.get(
-        'http://localhost:3001/api/evaluated-promises'
-      );
+      const response = await axios.get(`${API_BASE_URL}/evaluated-promises`);
       console.log('API Response:', response.data);
       console.log('First promise data:', response.data[0]);
       console.log('Rating in first promise:', response.data[0]?.rating);

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import axios from 'axios';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 import { useAuth } from '../contexts/useAuth';
 
 interface AxiosErrorResponse {
@@ -64,10 +65,7 @@ const RegisterForm = ({
         requestData.invitation_token = invitationToken;
       }
 
-      const response = await axios.post(
-        'http://localhost:3001/api/register',
-        requestData
-      );
+      const response = await axios.post(`${API_BASE_URL}/register`, requestData);
 
       console.log('Registration response:', response.data);
       setToken(response.data.token);
@@ -75,9 +73,7 @@ const RegisterForm = ({
       try {
         axios.defaults.headers.common['Authorization'] =
           `Bearer ${response.data.token}`;
-        const userResponse = await axios.get(
-          'http://localhost:3001/api/get_me'
-        );
+        const userResponse = await axios.get(`${API_BASE_URL}/get_me`);
         console.log('User info after registration:', userResponse.data);
       } catch (userError) {
         console.error('Failed to get user info after registration:', userError);

--- a/frontend/src/contexts/AuthProvider.tsx
+++ b/frontend/src/contexts/AuthProvider.tsx
@@ -4,6 +4,8 @@ import axios from 'axios';
 import { AuthContext } from './AuthContext';
 import type { AuthContextType } from './AuthContext';
 
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+
 interface AuthProviderProps {
   children: ReactNode;
 }
@@ -23,7 +25,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         console.log('Token found:', token);
         axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
         console.log('Making request to /api/get_me with token:', token);
-        const response = await axios.get('http://localhost:3001/api/get_me');
+        const response = await axios.get(`${API_BASE_URL}/get_me`);
         console.log('Auth response:', response.data);
         setCurrentUser(response.data.current_user);
         setPartner(response.data.partner);
@@ -53,7 +55,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     if (token && !partner) {
       const interval = setInterval(async (): Promise<void> => {
         try {
-          const response = await axios.get('http://localhost:3001/api/get_me', {
+          const response = await axios.get(`${API_BASE_URL}/get_me`, {
             headers: {
               Authorization: `Bearer ${token}`,
             },


### PR DESCRIPTION
# 概要
デプロイ時に本番環境用のCORSへの対応ができてないため、
バックエンドでリクエスを受け取れない状態になっていた。

# 修正内容
フロントのAPI呼び出しを環境変数経由に置換。
Vite前提でキーはVITE_API_URLに変更。
フロントのルートディレクトリに本番と開発用の.envファイルを作成。
それぞれで本番用と開発用のVITE_API_URLを設定。