### PR TITLE
デプロイ時のゲストログインエラーの解消

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -91,4 +91,5 @@ jobs:
 
             docker compose -f docker-compose.prod.yml pull
             docker compose -f docker-compose.prod.yml run --rm api bundle exec rails db:migrate
+            docker compose -f docker-compose.prod.yml run --rm api bundle exec rails db:seed
             docker compose -f docker-compose.prod.yml up -d --remove-orphans

--- a/backend/app/controllers/api/sessions_controller.rb
+++ b/backend/app/controllers/api/sessions_controller.rb
@@ -13,17 +13,15 @@ class Api::SessionsController < ApplicationController
   end
 
   def guest_login
-    # テストユーザー1でゲストログイン
-    guest_user = User.find_by(email: "test1@example.com")
-
-    if guest_user
-      token = encode_token(user_id: guest_user.id)
-      render json: {
-        token: token,
-        message: "ゲストユーザーとしてログインしました"
-      }, status: :ok
-    else
-      render json: { error: "ゲストユーザーが見つかりません" }, status: :not_found
+    guest_user = User.find_or_create_by!(email: 'test1@example.com') do |u|
+      u.name = 'テストユーザー1'
     end
+    UserCredential.find_or_create_by!(user: guest_user) do |cred|
+      cred.password = 'password123'
+      cred.password_confirmation = 'password123'
+    end
+  
+    token = encode_token(user_id: guest_user.id)
+    render json: { token:, message: "ゲストユーザーとしてログインしました" }, status: :ok
   end
 end


### PR DESCRIPTION
# 概要
ゲストログインをする際に設定していたSEEDがCDの設定に組み込まれてないため、
デプロイした後にゲストログインをすることができない。

# 修正内容
cd.ymlファイル内でSEEDを読み込むように変更。
ゲストユーザーが見つからない場合でも作成するように変更。