### PR TITLE
リダイレクトエラーの修正

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -42,7 +42,8 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = false
+
 
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }


### PR DESCRIPTION
# 概要
ALBのヘルスチェックでHTTPSにリダイレクトすることでエラーが発生していた
# 修正内容
リダイレクトをしないように変更
