### PR TITLE
CI/CDワークフローの変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,9 @@ jobs:
     name: Build and Push Docker Images
     runs-on: ubuntu-latest
     needs: test
-    if: needs.test.outputs.should-build == 'true' && github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    outputs:
+      image-built: ${{ steps.build.outcome == 'success' }}
 
     steps:
       - name: Checkout repository
@@ -116,7 +118,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build and push backend image
-        if: needs.test.outputs.should-build == 'true'
+        id: build
         run: |
           cd backend
           docker build -t ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_API_REPOSITORY }}:latest .


### PR DESCRIPTION
# 概要
CI/CDワークフローの中でテストが終わったらCDが実行してしまい、ドッカーイメージをプッシュ出てない状態でデプロイしてしまう、また、CIのドッカーイメージのプッシュジョブがスキップされてしまう。

# 修正内容
CDの中にbuild-and-pushジョブの完了を待つ仕組みを追加、build-and-pushジョブの開始条件を簡略化。