### PR TITLE
インフラ用のドメイン許可

### DIFF
--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -1,6 +1,6 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "https://www.yubikirigenman.com"
+    origins "https://yubikirigenman.com", "https://www.yubikirigenman.com"
     resource "*", headers: :any, methods: [:get, :post, :put, :patch, :delete, :options, :head], credentials: true
   end
 end


### PR DESCRIPTION
# 概要
CORSの設定で追加したドメインが許可されていなかった
# 修正内容
追加したドメインを許可するように修正