### PR TITLE
フロント環境変数の引用ミスの修正

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
 
-  # Health check endpoint for ALB
+  # ALB用のヘルスチェックのためAPIルート外
   get "/health", to: "health#show"
 
   namespace :api do

--- a/frontend/src/components/AddPromiseModal.tsx
+++ b/frontend/src/components/AddPromiseModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
-const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 interface AddPromiseModalProps {
   isOpen: boolean;

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
-const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 import Sidebar from './Sidebar';
 import PromiseColumn from './PromiseColumn';
 import AddPromiseModal from './AddPromiseModal';

--- a/frontend/src/components/DissolvePartnershipModal.tsx
+++ b/frontend/src/components/DissolvePartnershipModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import axios from 'axios';
-const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 import { useAuth } from '../contexts/useAuth';
 
 interface DissolvePartnershipModalProps {

--- a/frontend/src/components/EditPromiseModal.tsx
+++ b/frontend/src/components/EditPromiseModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
-const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 import type { PromiseItem } from '../types';
 
 interface EditPromiseModalProps {

--- a/frontend/src/components/EvaluationModal.tsx
+++ b/frontend/src/components/EvaluationModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
-const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 import type { PromiseItem } from '../types';
 
 interface EvaluationModalProps {

--- a/frontend/src/components/EvaluationPage.tsx
+++ b/frontend/src/components/EvaluationPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import axios from 'axios';
-const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 import EvaluationModal from './EvaluationModal';
 import type { PromiseItem } from '../types';
 

--- a/frontend/src/components/InviteAcceptPage.tsx
+++ b/frontend/src/components/InviteAcceptPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
-const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 import LoginForm from './LoginForm';
 import RegisterForm from './RegisterForm';
 

--- a/frontend/src/components/InvitePartnerPage.tsx
+++ b/frontend/src/components/InvitePartnerPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
-const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 import { useAuth } from '../contexts/useAuth';
 
 const InvitePartnerPage = () => {

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import axios from 'axios';
-const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 import { useAuth } from '../contexts/useAuth';
 import RegisterForm from './RegisterForm';
 

--- a/frontend/src/components/PastEvaluationsPage.tsx
+++ b/frontend/src/components/PastEvaluationsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
-const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 import Sidebar from './Sidebar';
 import PromiseColumn from './PromiseColumn';
 import type { EvaluatedPromise } from '../types';

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import axios from 'axios';
-const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 import { useAuth } from '../contexts/useAuth';
 
 interface AxiosErrorResponse {

--- a/frontend/src/contexts/AuthProvider.tsx
+++ b/frontend/src/contexts/AuthProvider.tsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { AuthContext } from './AuthContext';
 import type { AuthContextType } from './AuthContext';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 interface AuthProviderProps {
   children: ReactNode;


### PR DESCRIPTION
# 概要
CDデプロイした先でゲストログインやログインをする時にエラーが発生する
→リクエストがAPI配下になっていなかった
→フロントのコードで参照して環境変数名とギットハブアクションで管理している
　環境変数名が一致していなかった

# 修正内容
フロントのコードでギットハブアクションで管理している
環境変数名を参照するように変更