### PR TITLE
ログインエラーの修正

### DIFF
--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -1,6 +1,17 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
-  allow do
-    origins "https://yubikirigenman.com", "https://www.yubikirigenman.com", "http://localhost:3000", "http://127.0.0.1:3000"
-    resource "*", headers: :any, methods: [:get, :post, :put, :patch, :delete, :options, :head], credentials: true
+  if Rails.env.development?
+    allow do
+      origins /^http:\/\/localhost:\d+/, /^http:\/\/127\.0\.0\.1:\d+/
+      resource "*", headers: :any,
+               methods: [:get, :post, :put, :patch, :delete, :options, :head],
+               credentials: true
+    end
+  else
+    allow do
+      origins "https://yubikirigenman.com", "https://www.yubikirigenman.com"
+      resource "*", headers: :any,
+               methods: [:get, :post, :put, :patch, :delete, :options, :head],
+               credentials: true
+    end
   end
 end


### PR DESCRIPTION
## 概要
開発環境でゲストログインをする際にエラーが発生してしまう

## 原因
CORS設定の正規表現が不完全だった


## 変更点

- cors.rb内の正規表現を%r{\Ahttp://localhost:\d+\z}→ /^http:\/\/localhost:\d+/に変更