### PR TITLE
アイコン表示切り替えの実装

### DIFF
--- a/backend/app/controllers/api/users_controller.rb
+++ b/backend/app/controllers/api/users_controller.rb
@@ -17,7 +17,8 @@ class Api::UsersController < ApplicationController
               current_user: {
                 id: user.id,
                 name: user.name,
-                email: user.email
+                email: user.email,
+                is_inviter: partnership ? (partnership.user_id == user.id) : nil
               },
               partner: partner ? {
                 id: partner.id,


### PR DESCRIPTION
## 概要
ユーザーのデフォルトアイコンが招待者と招待された側で同じになってしまう

## 変更点

- current_userにis_inviterフィールドを追加して、フロントでユーザーの区別をできるように変更