### PR TITLE
ちょっと一言機能のバックエンド側実装

### DIFF
--- a/backend/app/controllers/api/one_words_controller.rb
+++ b/backend/app/controllers/api/one_words_controller.rb
@@ -1,0 +1,50 @@
+class Api::OneWordsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    if current_user&.partnership
+      one_words = current_user.partnership.one_words
+        .includes(:sender)
+        .where(receiver_id: current_user.id)
+        .order(created_at: :desc)
+      
+      render json: one_words.map { |word|
+        {
+          id: word.id,
+          content: word.content,
+          created_at: word.created_at,
+          sender_name: word.sender.name
+        }
+      }
+    else
+      render json: []
+    end
+  end
+
+  def create
+    unless current_user.partnership
+      render json: { error: 'パートナーシップが存在しません' }, status: :unprocessable_entity
+      return
+    end
+
+    partner = current_user.partnership.partner_of(current_user)
+
+    one_word = current_user.partnership.one_words.build(
+      content: one_word_params[:content],
+      sender_id: current_user.id,
+      receiver_id: partner.id
+    )
+
+    if one_word.save
+      render json: { message: 'メッセージを送信しました' }, status: :created
+    else
+      render json: { error: one_word.errors.full_messages.join(', ') }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def one_word_params
+    params.require(:one_word).permit(:content)
+  end
+end

--- a/backend/app/models/one_word.rb
+++ b/backend/app/models/one_word.rb
@@ -1,7 +1,8 @@
 class OneWord < ApplicationRecord
-    belongs_to :partnership
-    belongs_to :sender, class_name: "User"
-    has_many :one_word_reads, dependent: :destroy
+  belongs_to :partnership
+  belongs_to :sender, class_name: "User"
+  belongs_to :receiver, class_name: "User"
+  has_many :one_word_reads, dependent: :destroy
 
-    validates :content, presence: true
+  validates :content, presence: true
 end

--- a/backend/app/models/partnership.rb
+++ b/backend/app/models/partnership.rb
@@ -6,4 +6,12 @@ class Partnership < ApplicationRecord
   belongs_to :invitation, optional: true
   belongs_to :user, class_name: "User", foreign_key: "user_id"
   belongs_to :partner, class_name: "User", foreign_key: "partner_id"
+
+  def partner_of(user)
+    if user_id == user.id
+      partner
+    else
+      self.user
+    end
+  end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -26,6 +26,9 @@ Rails.application.routes.draw do
     # パートナーシップ機能のルート
     delete "/partnerships/dissolve", to: "partnerships#dissolve"
 
+    # ちょっと一言のルート
+    resources :one_words, only: [:index, :create]
+
     # スケジュールタスク用のルーティング
     post "/scheduled_tasks/send_due_date_evaluations", to: "scheduled_tasks#send_due_date_evaluations"
     post "/scheduled_tasks/send_weekly_our_promises_evaluation", to: "scheduled_tasks#send_weekly_our_promises_evaluation"

--- a/backend/db/migrate/20250930101101_add_sender_and_receiver_to_one_words.rb
+++ b/backend/db/migrate/20250930101101_add_sender_and_receiver_to_one_words.rb
@@ -1,0 +1,12 @@
+class AddSenderAndReceiverToOneWords < ActiveRecord::Migration[7.2]
+  def change
+    add_column :one_words, :sender_id, :bigint, null: false
+    add_column :one_words, :receiver_id, :bigint, null: false
+
+    add_index :one_words, :sender_id
+    add_index :one_words, :receiver_id
+
+    add_foreign_key :one_words, :users, column: :sender_id
+    add_foreign_key :one_words, :users, column: :receiver_id
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_31_090421) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_30_101101) do
   create_table "invitations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "inviter_id", null: false
     t.string "token", null: false
@@ -25,7 +25,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_31_090421) do
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "sender_id", null: false
+    t.bigint "receiver_id", null: false
     t.index ["partnership_id"], name: "index_one_words_on_partnership_id"
+    t.index ["receiver_id"], name: "index_one_words_on_receiver_id"
+    t.index ["sender_id"], name: "index_one_words_on_sender_id"
   end
 
   create_table "one_words_reads", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -109,6 +113,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_31_090421) do
 
   add_foreign_key "invitations", "users", column: "inviter_id"
   add_foreign_key "one_words", "partnerships"
+  add_foreign_key "one_words", "users", column: "receiver_id"
+  add_foreign_key "one_words", "users", column: "sender_id"
   add_foreign_key "one_words_reads", "one_words"
   add_foreign_key "one_words_reads", "users"
   add_foreign_key "partnerships", "users"


### PR DESCRIPTION
## 概要

API側で一言を送信、受信できるよう実装

## 変更点

- 追加（APIコントローラー）
backend/app/controllers/api/one_words_controller.rb
- 追加（ルーティング）
backend/config/routes.rb
- 追加/修正（モデル）
backend/app/models/partnership.rb
partner_of(user) を追加（自分がuserならpartner、自分がpartnerならuserを返す）
- 追加（マイグレーション）
backend/db/migrate/20250930101101_add_sender_and_receiver_to_one_words.rb
one_words に sender_id:bigint, receiver_id:bigint を追加（null: false、index、FKを付与）