### PR TITLE
招待機能の修正

### DIFF
--- a/backend/app/controllers/api/invitations_controller.rb
+++ b/backend/app/controllers/api/invitations_controller.rb
@@ -13,12 +13,14 @@ class Api::InvitationsController < ApplicationController
     )
 
     if invitation.save
+      frontend_base_url = ENV.fetch('FRONTEND_BASE_URL', 'http://localhost:3000')
+      
       render json: {
         message: "招待を作成しました",
         invitation: {
           id: invitation.id,
           token: invitation.token,
-          invite_url: "#{request.base_url}/invite/#{invitation.token}"
+          invite_url: "#{frontend_base_url}/invite/#{invitation.token}"
         }
       }, status: :created
     else

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,13 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    env_file:
+       - ./backend/.env.development
     environment:
       DB_HOST: db
       MYSQL_ROOT_PASSWORD: password
       RAILS_ENV: development
       DISABLE_DATABASE_ENVIRONMENT_CHECK: '1'
-      GMAIL_USERNAME: your-email@gmail.com
-      GMAIL_PASSWORD: your-app-password
     tty: true
     stdin_open: true
 


### PR DESCRIPTION
## 概要

招待リンクを作成する際に、開発環境だと
ポート番号が変更されても固定されてしまっている
また、開発環境用のURLのみで生成されるようになっていた

## 変更点

- backend/.env.developmentを作成し、開発用のリンク作成用環境変数を設定
-ギットハブシークレットに本番用のリンク作成用環境変数を設定
- 環境変数を用いてリンクを作成するように変更