### PR TITLE
評価待ちの約束ページとサイドバーに通知表示の実装

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import About from './components/About';
 import InviteAcceptPage from './components/InviteAcceptPage';
 import InvitePartnerPage from './components/InvitePartnerPage';
 import { useAuth } from './contexts/useAuth';
+import PendingEvaluationsPage from './components/PendingEvaluationsPage';
 
 function App() {
   const { token } = useAuth();
@@ -48,6 +49,10 @@ function App() {
         />
         <Route path="/about" element={token ? <About /> : <LoginForm />} />
         <Route path="*" element={token ? <Dashboard /> : <LoginForm />} />
+        <Route
+          path="/pending-evaluations"
+          element={token ? <PendingEvaluationsPage /> : <LoginForm />}
+        />
       </Routes>
     </Router>
   );

--- a/frontend/src/components/PendingEvaluationsPage.tsx
+++ b/frontend/src/components/PendingEvaluationsPage.tsx
@@ -1,0 +1,207 @@
+// frontend/src/components/PendingEvaluationsPage.tsx
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import Sidebar from './Sidebar';
+import DissolvePartnershipModal from './DissolvePartnershipModal';
+import EvaluationModal from './EvaluationModal';
+import { useAuth } from '../contexts/useAuth';
+import type { PromiseItem } from '../types';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
+
+const PendingEvaluationsPage = () => {
+  const { token, currentUser, partner } = useAuth();
+  const [isDissolveModalOpen, setIsDissolveModalOpen] =
+    useState<boolean>(false);
+  const [isEvaluationModalOpen, setIsEvaluationModalOpen] =
+    useState<boolean>(false);
+  const [selectedPromise, setSelectedPromise] = useState<PromiseItem | null>(
+    null
+  );
+  const [pendingPromises, setPendingPromises] = useState<PromiseItem[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    fetchPendingPromises();
+  }, []);
+
+  const fetchPendingPromises = async (): Promise<void> => {
+    if (!token) return;
+
+    setIsLoading(true);
+    try {
+      // TODO: 実際のAPIエンドポイントに変更
+      const response = await axios.get(`${API_BASE_URL}/pending-evaluations`);
+      setPendingPromises(response.data);
+    } catch (error) {
+      console.error('評価待ちの約束の取得に失敗しました:', error);
+      // デモ用のダミーデータ
+      setPendingPromises([
+        {
+          id: 1,
+          content: '毎日おはようメッセージを送る',
+          due_date: '2024-01-15',
+          type: 'our_promise',
+          creator_id: currentUser?.id || 1,
+        },
+        {
+          id: 2,
+          content: '週末は一緒に散歩する',
+          due_date: '2024-01-20',
+          type: 'our_promise',
+          creator_id: partner?.id || 2,
+        },
+      ]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleOpenEvaluationModal = (promise: PromiseItem): void => {
+    setSelectedPromise(promise);
+    setIsEvaluationModalOpen(true);
+  };
+
+  const handleEvaluationSubmitted = async (): Promise<void> => {
+    await fetchPendingPromises();
+  };
+
+  // 評価待ちの約束を自分が作ったものと相手が作ったもので分ける
+  const myPendingPromises = pendingPromises.filter(
+    promise => currentUser && promise.creator_id === currentUser.id
+  );
+  const partnerPendingPromises = pendingPromises.filter(
+    promise => partner && promise.creator_id === partner.id
+  );
+
+  // タイトルを生成
+  const myPromisesTitle = currentUser
+    ? `${currentUser.name}の評価`
+    : 'わたしの評価';
+  const partnerPromisesTitle = partner
+    ? `${partner.name}の評価`
+    : 'パートナーの評価';
+
+  if (isLoading) {
+    return (
+      <div className="yubi-app">
+        <Sidebar onDissolvePartnership={() => setIsDissolveModalOpen(true)} />
+        <main className="yubi-main">
+          <div className="yubi-loading">
+            <p>評価待ちの約束を読み込み中...</p>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div className="yubi-app">
+      <Sidebar onDissolvePartnership={() => setIsDissolveModalOpen(true)} />
+
+      <main className="yubi-main">
+        <div className="yubi-board">
+          <div className="yubi-column">
+            <h2 className="yubi-column__header">
+              <span>{myPromisesTitle}</span>
+              <span className="yubi-badge yubi-badge--pending">
+                {myPendingPromises.length}件
+              </span>
+            </h2>
+            <div className="yubi-column__content">
+              {myPendingPromises.length === 0 ? (
+                <div className="yubi-empty-state">
+                  <p>評価待ちの約束はありません</p>
+                </div>
+              ) : (
+                myPendingPromises.map(promise => (
+                  <div
+                    key={promise.id}
+                    className="yubi-card yubi-card--pending"
+                  >
+                    <div className="yubi-card__content">{promise.content}</div>
+                    <div className="yubi-card__meta">
+                      <span className="yubi-card__due-date">
+                        期限:{' '}
+                        {new Date(promise.due_date).toLocaleDateString('ja-JP')}
+                      </span>
+                    </div>
+                    <div className="yubi-card__actions">
+                      <button
+                        className="yubi-button yubi-button--evaluate"
+                        onClick={() => handleOpenEvaluationModal(promise)}
+                      >
+                        🌟 評価する
+                      </button>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+
+          <div className="yubi-column">
+            <h2 className="yubi-column__header">
+              <span>{partnerPromisesTitle}</span>
+              <span className="yubi-badge yubi-badge--pending">
+                {partnerPendingPromises.length}件
+              </span>
+            </h2>
+            <div className="yubi-column__content">
+              {partnerPendingPromises.length === 0 ? (
+                <div className="yubi-empty-state">
+                  <p>評価待ちの約束はありません</p>
+                </div>
+              ) : (
+                partnerPendingPromises.map(promise => (
+                  <div
+                    key={promise.id}
+                    className="yubi-card yubi-card--pending"
+                  >
+                    <div className="yubi-card__content">{promise.content}</div>
+                    <div className="yubi-card__meta">
+                      <span className="yubi-card__due-date">
+                        期限:{' '}
+                        {new Date(promise.due_date).toLocaleDateString('ja-JP')}
+                      </span>
+                    </div>
+                    <div className="yubi-card__actions">
+                      <button
+                        className="yubi-button yubi-button--evaluate"
+                        onClick={() => handleOpenEvaluationModal(promise)}
+                      >
+                        🌟 評価する
+                      </button>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+
+        {pendingPromises.length === 0 && (
+          <div className="yubi-success-message">
+            <div className="yubi-success-icon">🎉</div>
+            <h3>すべての評価が完了しました！</h3>
+            <p>素晴らしいです！すべての約束の評価が完了しています。</p>
+          </div>
+        )}
+      </main>
+
+      <EvaluationModal
+        isOpen={isEvaluationModalOpen}
+        onClose={() => setIsEvaluationModalOpen(false)}
+        promise={selectedPromise}
+        onEvaluationSubmitted={handleEvaluationSubmitted}
+      />
+
+      <DissolvePartnershipModal
+        isOpen={isDissolveModalOpen}
+        onClose={() => setIsDissolveModalOpen(false)}
+      />
+    </div>
+  );
+};
+
+export default PendingEvaluationsPage;

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,12 +1,34 @@
 import { Link } from 'react-router-dom';
 import { useAuth } from '../contexts/useAuth';
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 interface SidebarProps {
   onDissolvePartnership?: () => void;
 }
 
 const Sidebar = ({ onDissolvePartnership }: SidebarProps) => {
-  const { setToken, partner, currentUser } = useAuth();
+  const { setToken, partner, currentUser, token } = useAuth();
+  const [pendingCount, setPendingCount] = useState<number>(0);
+
+  useEffect(() => {
+    if (token && partner) {
+      fetchPendingCount();
+    }
+  }, [token, partner]);
+
+  const fetchPendingCount = async (): Promise<void> => {
+    try {
+      const response = await axios.get(`${API_BASE_URL}/pending-evaluations`);
+      setPendingCount(response.data.length);
+    } catch (error) {
+      console.error('評価待ち件数の取得に失敗しました:', error);
+      // デモ用のダミーカウント
+      setPendingCount(Math.floor(Math.random() * 5));
+    }
+  };
 
   const handleLogout = (): void => {
     setToken(null);
@@ -107,6 +129,18 @@ const Sidebar = ({ onDissolvePartnership }: SidebarProps) => {
             onClick={handleNavLinkClick}
           >
             ちょっと一言
+          </Link>
+          <Link
+            to="/pending-evaluations"
+            className="yubi-sidebar__link"
+            onClick={handleNavLinkClick}
+          >
+            <span>評価待ちの約束</span>
+            {pendingCount > 0 && (
+              <span className="yubi-sidebar__notification-badge">
+                {pendingCount}
+              </span>
+            )}
           </Link>
           <Link
             to="/about"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -138,6 +138,19 @@ body.page-about {
   margin: 0;
 }
 
+.yubi-sidebar__notification-badge {
+  background-color: #ff4757;
+  color: white;
+  font-size: 12px;
+  font-weight: bold;
+  padding: 4px 8px;
+  border-radius: 12px;
+  margin-left: 8px;
+  min-width: 18px;
+  text-align: center;
+  line-height: 1;
+}
+
 /* --- メニュー開閉の仕組み --- */
 #yubi-nav-toggle {
   display: none;
@@ -1548,4 +1561,88 @@ body.page-about .yubi-main {
   color: var(--text-color-brown);
   font-style: italic;
   line-height: 1.4;
+}
+
+/* 評価待ちページ専用のスタイル */
+.yubi-page-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.yubi-page-title {
+  font-size: 2rem;
+  color: #333;
+  margin-bottom: 0.5rem;
+}
+
+.yubi-page-description {
+  color: #666;
+  font-size: 1rem;
+}
+
+.yubi-badge {
+  background: #ff6b6b;
+  color: white;
+  padding: 0.25rem 0.5rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: bold;
+}
+
+.yubi-badge--pending {
+  background: #ff6b6b;
+}
+
+.yubi-card--pending {
+  border-left: 4px solid #ff6b6b;
+  background: #fff5f5;
+}
+
+.yubi-card__meta {
+  margin: 0.5rem 0;
+  font-size: 0.875rem;
+  color: #666;
+}
+
+.yubi-card__actions {
+  margin-top: 1rem;
+  text-align: right;
+}
+
+.yubi-button--evaluate {
+  background: #ffd93d;
+  color: #333;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-weight: bold;
+}
+
+.yubi-button--evaluate:hover {
+  background: #ffc107;
+}
+
+.yubi-empty-state {
+  text-align: center;
+  padding: 2rem;
+  color: #999;
+}
+
+.yubi-success-message {
+  text-align: center;
+  padding: 3rem;
+  background: #f8f9fa;
+  border-radius: 8px;
+  margin: 2rem 0;
+}
+
+.yubi-success-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.yubi-loading {
+  text-align: center;
+  padding: 3rem;
+  color: #666;
 }


### PR DESCRIPTION
## 概要

評価待ちの約束をメールにて通知する方式をとっていたが
わかりにくいのと、メールを見逃すと評価不可になってしまうため
評価待ちの約束を一覧で表示するページを追加。

## 変更点

- PendingEvaluationsPage.tsxファイルの作成
- サイドバーに評価待ちの約束がある場合通知が出るようにフロントのUIを変更