### PR TITLE
評価待ち機能のAPI作

### DIFF
--- a/backend/app/controllers/api/pending_evaluations_controller.rb
+++ b/backend/app/controllers/api/pending_evaluations_controller.rb
@@ -1,0 +1,33 @@
+class Api::PendingEvaluationsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    if current_user&.partnership
+      # 評価待ちの約束を取得（評価が存在しない約束のみ）
+      # 現在のユーザーが作成した約束で、パートナーが評価していないもの
+      # または、パートナーが作成した約束で、現在のユーザーが評価していないもの
+      @pending_promises = current_user.partnership.promises
+        .left_joins(:promise_evaluation)
+        .where(promise_evaluations: { id: nil })
+        .includes(:creator)
+        .order(:created_at)
+
+      response_data = @pending_promises.map do |promise|
+        {
+          id: promise.id,
+          content: promise.content,
+          due_date: promise.due_date,
+          type: promise.type,
+          creator_id: promise.creator_id,
+          creator_name: promise.creator.name,
+          created_at: promise.created_at
+        }
+      end
+
+      Rails.logger.info "PendingEvaluations API Response: #{response_data}"
+      render json: response_data
+    else
+      render json: [], status: :ok
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
 
-  # ALB用のヘルスチェックのためAPIルート外
+  # ALB用のヘルスチェックのためAPIルート
   get "/health", to: "health#show"
 
   namespace :api do
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
       resources :promise_evaluations, only: [ :create ]
     end
     get "/evaluated-promises", to: "evaluated_promises#index"
+    get "/pending-evaluations", to: "pending_evaluations#index"
     get "/evaluation_pages/:id", to: "evaluation_pages#show"
     get "/get_me", to: "users#me"
     post "/evaluation_emails", to: "evaluation_emails#create"

--- a/frontend/src/components/PendingEvaluationsPage.tsx
+++ b/frontend/src/components/PendingEvaluationsPage.tsx
@@ -29,8 +29,11 @@ const PendingEvaluationsPage = () => {
 
     setIsLoading(true);
     try {
-      // TODO: 実際のAPIエンドポイントに変更
-      const response = await axios.get(`${API_BASE_URL}/pending-evaluations`);
+      const response = await axios.get(`${API_BASE_URL}/pending-evaluations`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
       setPendingPromises(response.data);
     } catch (error) {
       console.error('評価待ちの約束の取得に失敗しました:', error);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -21,7 +21,11 @@ const Sidebar = ({ onDissolvePartnership }: SidebarProps) => {
 
   const fetchPendingCount = async (): Promise<void> => {
     try {
-      const response = await axios.get(`${API_BASE_URL}/pending-evaluations`);
+      const response = await axios.get(`${API_BASE_URL}/pending-evaluations`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
       setPendingCount(response.data.length);
     } catch (error) {
       console.error('評価待ち件数の取得に失敗しました:', error);


### PR DESCRIPTION
## 概要

評価されてない約束を取得するためのAPIを作成

## 変更点

- backend/app/controllers/api/pending_evaluations_controller.rbの作成
- ルートの追加