### PR TITLE
過去の約束の年月変更UI実装

### DIFF
--- a/backend/app/controllers/api/evaluated_promises_controller.rb
+++ b/backend/app/controllers/api/evaluated_promises_controller.rb
@@ -17,6 +17,7 @@ class Api::EvaluatedPromisesController < ApplicationController
           type: promise.type,
           creator_id: promise.creator_id,
           rating: promise.promise_evaluation.rating,
+          evaluation_text: promise.promise_evaluation.evaluation_text,
           evaluation_date: promise.promise_evaluation.created_at,
           evaluator_name: promise.promise_evaluation.evaluator.name
         }

--- a/frontend/src/components/pages/PastEvaluationsPage.tsx
+++ b/frontend/src/components/pages/PastEvaluationsPage.tsx
@@ -12,9 +12,26 @@ const PastEvaluationsPage = () => {
     EvaluatedPromise[]
   >([]);
 
+  // 検索用のステート
+  const currentDate = new Date();
+  const [selectedYear, setSelectedYear] = useState<number>(
+    currentDate.getFullYear()
+  );
+  const [selectedMonth, setSelectedMonth] = useState<number>(
+    currentDate.getMonth() + 1
+  );
+  const [isSearchOpen, setIsSearchOpen] = useState<boolean>(false);
+
+  // 月の選択肢
+  const months = Array.from({ length: 12 }, (_, i) => i + 1);
+
   useEffect(() => {
     const fetchEvaluatedPromises = async (): Promise<void> => {
       try {
+        // TODO: 後でAPI実装時に年月をパラメータとして渡す
+        // const response: ApiResponse<EvaluatedPromise[]> = await apiClient.get(
+        //   `/evaluated-promises?year=${selectedYear}&month=${selectedMonth}`
+        // );
         const response: ApiResponse<EvaluatedPromise[]> = await apiClient.get(
           '/evaluated-promises'
         );
@@ -32,7 +49,7 @@ const PastEvaluationsPage = () => {
     };
 
     fetchEvaluatedPromises();
-  }, []);
+  }, [selectedYear, selectedMonth]);
 
   // 約束をタイプ別に分類
   const myPromises = evaluatedPromises.filter(
@@ -48,28 +65,96 @@ const PastEvaluationsPage = () => {
   // タイトル生成
   const getTitle = (type: string) => {
     if (type === 'my_promise') {
-      return 'あなたの過去の約束';
+      return 'あなたの約束';
     } else if (type === 'our_promise') {
-      return 'ふたりの過去の約束';
+      return 'ふたりの約束';
     } else if (type === 'partner_promise') {
-      return 'パートナーの過去の約束';
+      return 'パートナーの約束';
     }
     return '過去の約束';
+  };
+
+  // 検索ボタンのトグル
+  const toggleSearch = () => {
+    setIsSearchOpen(!isSearchOpen);
+  };
+
+  // 検索実行（年月変更時に自動的にuseEffectで再取得される）
+  const handleSearch = () => {
+    console.log(`検索: ${selectedYear}年${selectedMonth}月の約束`);
+    setIsSearchOpen(false);
   };
 
   return (
     <div className="app-wrapper">
       <Sidebar />
       <main className="board-container">
+        {/* 検索ヘッダー */}
+        <div className="yubi-past-evaluations-header">
+          <div className="yubi-search-section">
+            <h1 className="yubi-past-evaluations-title">
+              {selectedYear}年{selectedMonth}月の過去の約束
+            </h1>
+            <button
+              onClick={toggleSearch}
+              className="yubi-search-toggle-button"
+              title="年月で検索"
+            >
+              ▼
+            </button>
+          </div>
+
+          {/* 検索ドロップダウン */}
+          {isSearchOpen && (
+            <div className="yubi-search-dropdown">
+              <div className="yubi-search-controls">
+                <div className="yubi-search-field">
+                  <label htmlFor="year-input">年</label>
+                  <input
+                    id="year-input"
+                    type="number"
+                    value={selectedYear}
+                    onChange={e => setSelectedYear(Number(e.target.value))}
+                    className="yubi-search-input"
+                    min="2025"
+                    max="2125"
+                    placeholder="2025"
+                  />
+                </div>
+
+                <div className="yubi-search-field">
+                  <label htmlFor="month-select">月</label>
+                  <select
+                    id="month-select"
+                    value={selectedMonth}
+                    onChange={e => setSelectedMonth(Number(e.target.value))}
+                    className="yubi-search-select"
+                  >
+                    {months.map(month => (
+                      <option key={month} value={month}>
+                        {month}月
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <button
+                  onClick={handleSearch}
+                  className="yubi-button yubi-button--primary yubi-search-apply-button"
+                >
+                  検索
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+
         <div className="yubi-board">
           <PromiseColumn
             title={getTitle('my_promise')}
             promises={myPromises}
             onAdd={() => {}}
             showAddButton={false}
-            onEdit={() => {}}
-            onDelete={() => {}}
-            onEvaluate={() => {}}
             showEvaluationButton={false}
           />
 
@@ -78,9 +163,6 @@ const PastEvaluationsPage = () => {
             promises={ourPromises}
             onAdd={() => {}}
             showAddButton={false}
-            onEdit={() => {}}
-            onDelete={() => {}}
-            onEvaluate={() => {}}
             showEvaluationButton={false}
           />
 
@@ -89,9 +171,6 @@ const PastEvaluationsPage = () => {
             promises={partnerPromises}
             onAdd={() => {}}
             showAddButton={false}
-            onEdit={() => {}}
-            onDelete={() => {}}
-            onEvaluate={() => {}}
             showEvaluationButton={false}
           />
         </div>

--- a/frontend/src/components/pages/RecordPage.tsx
+++ b/frontend/src/components/pages/RecordPage.tsx
@@ -64,7 +64,7 @@ const RecordPage = () => {
             <div className="user-name">
               あなた
             </div>
-            <div className="score-label">これまでの平均スコア</div>
+            <div className="score-label">今月の平均スコア</div>
             <div className="score-value">
               {userStats?.inviter.average_score.toFixed(1) || '0.0'}
             </div>
@@ -91,7 +91,7 @@ const RecordPage = () => {
             <div className="user-name">
               パートナー
             </div>
-            <div className="score-label">これまでの平均スコア</div>
+            <div className="score-label">今月の平均スコア</div>
             <div className="score-value">
               {userStats?.invitee.average_score.toFixed(1) || '0.0'}
             </div>

--- a/frontend/src/components/ui/PostIt.tsx
+++ b/frontend/src/components/ui/PostIt.tsx
@@ -52,11 +52,6 @@ const PostIt = ({
   return (
     <div className="yubi-card">
       {content}
-      {evaluationText && (
-        <div className="yubi-evaluation-comment">
-          <p className="yubi-evaluation-text">"{evaluationText}"</p>
-        </div>
-      )}
       <footer className="yubi-card__footer">
         <div className="yubi-actions">
           {onEdit && (
@@ -97,19 +92,29 @@ const PostIt = ({
           )}
         </div>
         <div className="yubi-card__info">
-          <div className="yubi-card__bottom-left">
-            {rating && renderStars(rating)}
-          </div>
-          {promiseType !== 'our_promise' && (
-            <div className="yubi-card__bottom-right">
-              <span>
-                評価日:{' '}
-                {evaluationDate
-                  ? new Date(evaluationDate).toLocaleDateString('ja-JP')
-                  : dueDate || 'なし'}
-              </span>
+          {evaluationText && (
+            <div className="yubi-evaluation-comment-section">
+              <h4 className="yubi-evaluation-comment-title">評価コメント</h4>
+              <div className="yubi-evaluation-comment">
+                <p className="yubi-evaluation-text">{evaluationText}</p>
+              </div>
             </div>
           )}
+          <div className="yubi-card__bottom-row">
+            <div className="yubi-card__bottom-left">
+              {rating && renderStars(rating)}
+            </div>
+            {(rating || evaluationDate) && (
+              <div className="yubi-card__bottom-right">
+                <span>
+                  評価日:{' '}
+                  {evaluationDate
+                    ? new Date(evaluationDate).toLocaleDateString('ja-JP')
+                    : dueDate || 'なし'}
+                </span>
+              </div>
+            )}
+          </div>
         </div>
       </footer>
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -329,10 +329,16 @@ body.page-about .yubi-main {
 
 .yubi-card__info {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
+  flex-direction: column;
   width: 100%;
   gap: 10px;
+}
+
+.yubi-card__bottom-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
 }
 
 .yubi-card__bottom-left {
@@ -343,7 +349,6 @@ body.page-about .yubi-main {
 .yubi-card__bottom-right {
   display: flex;
   align-items: center;
-  margin-left: auto;
 }
 
 .yubi-card__meta {
@@ -450,20 +455,30 @@ body.page-about .yubi-main {
   color: var(--text-color-brown);
 }
 
+.yubi-evaluation-comment-section {
+  width: 100%;
+  margin-bottom: 12px;
+}
+
+.yubi-evaluation-comment-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-color-brown);
+  margin: 0 0 6px 0;
+}
+
 .yubi-evaluation-comment {
-  margin: 10px 0;
+  margin: 0;
   padding: 8px 12px;
   background-color: rgba(255, 255, 255, 0.8);
   border-radius: 8px;
-  border-left: 3px solid var(--leaf-green);
 }
 
 .yubi-evaluation-text {
   margin: 0;
-  font-size: 14px;
+  font-size: 16px;
   color: var(--text-color-brown);
-  font-style: italic;
-  line-height: 1.4;
+  line-height: 1.6;
 }
 
 /* アクションボタン */
@@ -905,7 +920,7 @@ body.page-about .yubi-main {
   text-align: center;
 }
 
-/* レポート */
+/* ふたりの評価 */
 .yubi-report-fullscreen-container,
 .report-fullscreen-container {
   width: 100%;
@@ -1727,6 +1742,116 @@ body.page-about .yubi-main {
   text-align: center;
 }
 
+/* 過去の約束検索 */
+.yubi-past-evaluations-header {
+  margin-bottom: 30px;
+}
+
+.yubi-search-section {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 15px;
+}
+
+.yubi-past-evaluations-title {
+  font-size: 24px;
+  font-weight: 800;
+  color: var(--text-color-brown);
+  margin: 0;
+  text-align: center;
+}
+
+.yubi-search-toggle-button {
+  width: 36px;
+  height: 36px;
+  background-color: var(--heading-color);
+  border: none;
+  border-radius: 50%;
+  font-size: 16px;
+  cursor: pointer;
+  box-shadow: 0 3px 0 #043a40;
+  transition: all 0.1s ease-out;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: white;
+}
+
+.yubi-search-toggle-button:hover {
+  background-color: #086673;
+}
+
+.yubi-search-toggle-button:active {
+  transform: translateY(2px);
+  box-shadow: 0 1px 0 #043a40;
+}
+
+.yubi-search-dropdown {
+  background-color: var(--panel-bg);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  margin: 0 auto 20px;
+  max-width: 500px;
+}
+
+.yubi-search-controls {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.yubi-search-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.yubi-search-field label {
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--text-color-brown);
+}
+
+.yubi-search-input,
+.yubi-search-select {
+  padding: 10px 12px;
+  border: 2px solid #ddd;
+  border-radius: 12px;
+  font-size: 16px;
+  font-family: var(--font-rounded);
+  color: var(--text-color-brown);
+  background-color: #fff;
+  min-width: 100px;
+  transition: border-color 0.2s;
+}
+
+.yubi-search-select {
+  cursor: pointer;
+}
+
+.yubi-search-input:focus,
+.yubi-search-select:focus {
+  outline: none;
+  border-color: var(--leaf-green);
+}
+
+.yubi-search-input[type='number']::-webkit-inner-spin-button,
+.yubi-search-input[type='number']::-webkit-outer-spin-button {
+  opacity: 1;
+}
+
+.yubi-search-apply-button {
+  padding: 10px 8px;
+  white-space: nowrap;
+  font-size: 14px;
+  min-width: auto;
+}
+
 /* バッジ */
 .yubi-badge {
   background: #ff6b6b;
@@ -1950,6 +2075,38 @@ body.page-about .yubi-main {
   .record-page {
     padding: 20px 15px;
   }
+
+  .yubi-search-section {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .yubi-past-evaluations-title {
+    font-size: 20px;
+  }
+
+  .yubi-search-dropdown {
+    max-width: 100%;
+    width: 100%;
+  }
+
+  .yubi-search-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .yubi-search-field {
+    width: 100%;
+  }
+
+  .yubi-search-input,
+  .yubi-search-select {
+    width: 100%;
+  }
+
+  .yubi-search-apply-button {
+    width: 100%;
+  }
 }
 
 @media (max-width: 480px) {
@@ -1992,5 +2149,19 @@ body.page-about .yubi-main {
   .yubi-main--pending-evaluations {
     padding-top: 120px;
     max-width: 95%;
+  }
+
+  .yubi-search-toggle-button {
+    width: 32px;
+    height: 32px;
+    font-size: 14px;
+  }
+
+  .yubi-past-evaluations-title {
+    font-size: 18px;
+  }
+
+  .yubi-page-title {
+    font-size: 1.2rem;
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -29,6 +29,7 @@ export interface EvaluatedPromise {
   type: string;
   creator_id: number;
   rating: number;
+  evaluation_text?: string;
   evaluation_date: string;
   evaluator_name: string;
 }


### PR DESCRIPTION
## 概要

過去の約束が全て表示される仕様になっていたので、年月で分けて表示できるように変更

## 変更点

- 年月を変更できるUIを追加
- 選択した年月の過去の約束が表示されるように変更(デフォルトは現在の年月の過去の約束が表示)
- ページ上部に年月を表示するようにしたため、各カラムのタイトルを〇〇の約束に変更