### PR TITLE
年月検索のAPI実装

### DIFF
--- a/backend/app/models/promise.rb
+++ b/backend/app/models/promise.rb
@@ -11,6 +11,43 @@ class Promise < ApplicationRecord
     validates :content, presence: true
     validates :type, presence: true
 
+    # スコープ：評価済みの約束のみ
+    scope :evaluated, -> {
+      joins(:promise_evaluation)
+        .includes(:promise_evaluation, :creator)
+    }
+
+    # スコープ：指定された年月で評価された約束
+    scope :by_evaluation_month, ->(year, month) {
+      return all if year.blank? || month.blank?
+
+      start_date = Date.new(year.to_i, month.to_i, 1).beginning_of_day
+      end_date = start_date.end_of_month.end_of_day
+
+      where("promise_evaluations.created_at >= ? AND promise_evaluations.created_at <= ?",
+            start_date, end_date)
+    }
+
+    # スコープ：評価日の降順でソート
+    scope :ordered_by_evaluation, -> {
+      order("promise_evaluations.created_at DESC")
+    }
+
+    # レスポンス用のハッシュに変換
+    def to_evaluation_response
+      {
+        id: id,
+        content: content,
+        due_date: due_date,
+        type: type,
+        creator_id: creator_id,
+        rating: promise_evaluation.rating,
+        evaluation_text: promise_evaluation.evaluation_text,
+        evaluation_date: promise_evaluation.created_at,
+        evaluator_name: promise_evaluation.evaluator.name
+      }
+    end
+
     after_validation :log_validation_errors
 
     private

--- a/frontend/src/components/pages/PastEvaluationsPage.tsx
+++ b/frontend/src/components/pages/PastEvaluationsPage.tsx
@@ -28,12 +28,8 @@ const PastEvaluationsPage = () => {
   useEffect(() => {
     const fetchEvaluatedPromises = async (): Promise<void> => {
       try {
-        // TODO: 後でAPI実装時に年月をパラメータとして渡す
-        // const response: ApiResponse<EvaluatedPromise[]> = await apiClient.get(
-        //   `/evaluated-promises?year=${selectedYear}&month=${selectedMonth}`
-        // );
         const response: ApiResponse<EvaluatedPromise[]> = await apiClient.get(
-          '/evaluated-promises'
+          `/evaluated-promises?year=${selectedYear}&month=${selectedMonth}`
         );
 
         if (response.error) {


### PR DESCRIPTION
## 概要

過去の約束で年月による検索機能用のAPIの実装

## 変更点

- 年月でフィルタリングして評価済みの約束を取得するように変更
- コントローラー内にある移設できるコードをモデルに移設