### PR TITLE
もらった一言の通知機能の実装

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import HitokotoPage from './components/pages/HitokotoPage';
 import About from './components/pages/About';
 import InvitePartnerPage from './components/pages/InvitePartnerPage';
 import { useAuth } from './contexts/useAuth';
+import { HitokotoNotificationProvider } from './contexts/HitokotoNotificationContext';
 import PendingEvaluationsPage from './components/pages/PendingEvaluationsPage';
 
 function App() {
@@ -45,7 +46,8 @@ function App() {
 
   return (
     <Router>
-      <Routes>
+      <HitokotoNotificationProvider>
+        <Routes>
         <Route
           path="/invite-partner"
           element={token && currentUser ? <InvitePartnerPage /> : <LoginForm />}
@@ -79,7 +81,8 @@ function App() {
             token && currentUser ? <PendingEvaluationsPage /> : <LoginForm />
           }
         />
-      </Routes>
+        </Routes>
+      </HitokotoNotificationProvider>
     </Router>
   );
 }

--- a/frontend/src/components/forms/LoginForm.tsx
+++ b/frontend/src/components/forms/LoginForm.tsx
@@ -13,9 +13,7 @@ interface GuestLoginResponse {
   message: string;
 }
 
-interface LoginFormProps {}
-
-const LoginForm = ({}: LoginFormProps) => {
+const LoginForm = (): React.JSX.Element => {
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [error, setError] = useState<string>('');
@@ -37,15 +35,17 @@ const LoginForm = ({}: LoginFormProps) => {
       );
 
       if (response.error) {
-        setError(
-          response.error.error || 'メールアドレスまたはパスワードが違います。'
-        );
+        const errorMessage =
+          response.error.error || 'メールアドレスまたはパスワードが違います。';
+        setError(errorMessage);
       } else {
         setToken(response.data?.token || null);
       }
     } catch (err) {
       console.error('ログイン失敗:', err);
-      setError('予期せぬエラーが発生しました。');
+      setError(
+        'ログインに失敗しました。メールアドレスとパスワードを確認してください。'
+      );
     }
   };
 
@@ -58,13 +58,18 @@ const LoginForm = ({}: LoginFormProps) => {
         await apiClient.post('/guest_login');
 
       if (response.error) {
-        setError(response.error.error || 'ゲストログインに失敗しました。');
+        setError(
+          response.error.error ||
+            'ゲストログインに失敗しました。しばらく時間をおいて再度お試しください。'
+        );
       } else {
         setToken(response.data?.token || null);
       }
     } catch (err) {
       console.error('ゲストログイン失敗:', err);
-      setError('予期せぬエラーが発生しました。');
+      setError(
+        'ゲストログインに失敗しました。しばらく時間をおいて再度お試しください。'
+      );
     } finally {
       setIsGuestLoggingIn(false);
     }

--- a/frontend/src/components/pages/Dashboard.tsx
+++ b/frontend/src/components/pages/Dashboard.tsx
@@ -140,6 +140,7 @@ const Dashboard = () => {
             onDelete={handleDeletePromise}
             onEvaluate={handleOpenEvaluationModal}
             showEvaluationButton={true}
+            currentUserId={currentUser?.id}
           />
           <PromiseColumn
             title={partnerPromisesTitle}

--- a/frontend/src/components/ui/PostIt.tsx
+++ b/frontend/src/components/ui/PostIt.tsx
@@ -11,6 +11,7 @@ interface PostItProps {
   onDelete?: () => void;
   onEvaluate?: () => void;
   showEvaluationButton?: boolean;
+  isPickup?: boolean;
 }
 
 const PostIt = ({
@@ -19,11 +20,12 @@ const PostIt = ({
   rating,
   evaluationText,
   evaluationDate,
-  promiseType,
+  // promiseType, // 未使用のためコメントアウト
   onEdit,
   onDelete,
   onEvaluate,
   showEvaluationButton = false,
+  isPickup = false,
 }: PostItProps) => {
   console.log('PostIt rendering with:', {
     content,
@@ -50,7 +52,8 @@ const PostIt = ({
   };
 
   return (
-    <div className="yubi-card">
+    <div className={`yubi-card ${isPickup ? 'yubi-card--pickup' : ''}`}>
+      {isPickup && <div className="yubi-pickup-header">Pick Up!</div>}
       {content}
       <footer className="yubi-card__footer">
         <div className="yubi-actions">
@@ -63,7 +66,7 @@ const PostIt = ({
                 onEdit();
               }}
             >
-              ✏️
+              <span className="material-symbols-outlined">edit</span>
             </a>
           )}
           {onDelete && (
@@ -75,10 +78,10 @@ const PostIt = ({
                 onDelete();
               }}
             >
-              🗑️
+              <span className="material-symbols-outlined">delete</span>
             </a>
           )}
-          {onEvaluate && showEvaluationButton && (
+          {onEvaluate && showEvaluationButton && !isPickup && (
             <a
               href="#"
               className="yubi-action-button"
@@ -87,7 +90,7 @@ const PostIt = ({
                 onEvaluate();
               }}
             >
-              ⭐
+              <span className="material-symbols-outlined">kid_star</span>
             </a>
           )}
         </div>

--- a/frontend/src/components/ui/PromiseColumn.tsx
+++ b/frontend/src/components/ui/PromiseColumn.tsx
@@ -10,6 +10,7 @@ interface PromiseColumnProps {
   onDelete?: (promise: PromiseItem) => void;
   onEvaluate?: (promise: PromiseItem) => void;
   showEvaluationButton?: boolean;
+  currentUserId?: number;
 }
 
 const PromiseColumn = ({
@@ -21,12 +22,27 @@ const PromiseColumn = ({
   onDelete,
   onEvaluate,
   showEvaluationButton = false,
+  // currentUserId, // 現在未使用のためコメントアウト
 }: PromiseColumnProps) => {
   console.log(`PromiseColumn ${title}:`, promises);
   console.log(`PromiseColumn ${title} - promises length:`, promises.length);
   promises.forEach((promise, index) => {
     console.log(`PromiseColumn ${title} - promise ${index}:`, promise);
   });
+
+  // 今週評価するふたりの約束を判定する関数
+  const isWeeklyEvaluationTarget = (
+    promise: PromiseItem,
+    index: number
+  ): boolean => {
+    // ふたりの約束で、一番上（index === 0）で、評価ボタンが表示される場合
+    return (
+      promise.type === 'our_promise' &&
+      index === 0 &&
+      showEvaluationButton &&
+      !!onEvaluate
+    );
+  };
 
   return (
     <div className="yubi-column">
@@ -56,6 +72,7 @@ const PromiseColumn = ({
                 : undefined
             }
             showEvaluationButton={showEvaluationButton && index === 0}
+            isPickup={isWeeklyEvaluationTarget(promise, index)}
           />
         ))}
       </div>

--- a/frontend/src/contexts/HitokotoNotificationContext.tsx
+++ b/frontend/src/contexts/HitokotoNotificationContext.tsx
@@ -1,0 +1,135 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+} from 'react';
+import type { ReactNode } from 'react';
+import { useAuth } from './useAuth';
+import { apiClient } from '../lib/api';
+import type { ApiResponse } from '../lib/api';
+
+interface OneWord {
+  id: number;
+  content: string;
+  created_at: string;
+}
+
+interface HitokotoNotificationContextType {
+  hasUnreadHitokoto: boolean;
+  markAsRead: () => Promise<void>;
+  refreshUnreadStatus: () => Promise<void>;
+  hasVisitedHitokotoPage: boolean;
+  resetVisitStatus: () => void;
+}
+
+const HitokotoNotificationContext = createContext<
+  HitokotoNotificationContextType | undefined
+>(undefined);
+
+interface HitokotoNotificationProviderProps {
+  children: ReactNode;
+}
+
+export const HitokotoNotificationProvider = ({
+  children,
+}: HitokotoNotificationProviderProps) => {
+  const [hasUnreadHitokoto, setHasUnreadHitokoto] = useState<boolean>(false);
+  const [hasVisitedHitokotoPage, setHasVisitedHitokotoPage] =
+    useState<boolean>(false);
+  const { token, partner } = useAuth();
+
+  const refreshUnreadStatus = useCallback(async (): Promise<void> => {
+    // 認証されていない場合やパートナーがいない場合は通知を表示しない
+    if (!token || !partner) {
+      setHasUnreadHitokoto(false);
+      return;
+    }
+
+    try {
+      const response: ApiResponse<OneWord[]> =
+        await apiClient.get('/one_words');
+
+      if (response.error) {
+        console.error('一言の取得に失敗しました:', response.error);
+        setHasUnreadHitokoto(false);
+      } else {
+        // 一言の数をチェック
+        const oneWords = response.data || [];
+        const currentCount = oneWords.length;
+        const savedCount = parseInt(
+          localStorage.getItem('hitokoto_count') || '0',
+          10
+        );
+
+        // 保存された数より増えていたら通知を表示
+        const hasNewWords = currentCount > savedCount;
+
+        console.log('一言通知チェック:', {
+          currentCount,
+          savedCount,
+          hasNewWords,
+        });
+        setHasUnreadHitokoto(hasNewWords);
+      }
+    } catch (error) {
+      console.error('一言の取得エラー:', error);
+      setHasUnreadHitokoto(false);
+    }
+  }, [token, partner]);
+
+  const markAsRead = useCallback(async (): Promise<void> => {
+    console.log('通知を消します');
+    // 現在の一言数を記録
+    try {
+      const response: ApiResponse<OneWord[]> =
+        await apiClient.get('/one_words');
+      if (!response.error && response.data) {
+        const currentCount = response.data.length;
+        localStorage.setItem('hitokoto_count', currentCount.toString());
+        console.log('一言数を記録:', currentCount);
+      }
+    } catch (error) {
+      console.error('一言の取得エラー:', error);
+    }
+    setHasUnreadHitokoto(false);
+  }, []);
+
+  const resetVisitStatus = useCallback((): void => {
+    // 一言送信時は既読日時をリセットしない（新しい一言が来たら通知を表示するため）
+    setHasVisitedHitokotoPage(false);
+  }, []);
+
+  // 初回マウント時のみ通知をチェック
+  useEffect(() => {
+    if (token && partner) {
+      refreshUnreadStatus();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <HitokotoNotificationContext.Provider
+      value={{
+        hasUnreadHitokoto,
+        markAsRead,
+        refreshUnreadStatus,
+        hasVisitedHitokotoPage,
+        resetVisitStatus,
+      }}
+    >
+      {children}
+    </HitokotoNotificationContext.Provider>
+  );
+};
+
+export const useHitokotoNotification = (): HitokotoNotificationContextType => {
+  const context = useContext(HitokotoNotificationContext);
+  if (context === undefined) {
+    throw new Error(
+      'useHitokotoNotification must be used within a HitokotoNotificationProvider'
+    );
+  }
+  return context;
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,6 @@
 /* フォント */
 @import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200');
 
 /* 変数 */
 :root {
@@ -140,6 +141,13 @@ body.page-about .yubi-main {
   margin: 0;
 }
 
+.yubi-sidebar__notification-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 8px;
+}
+
 .yubi-sidebar__notification-badge {
   background-color: #ff4757;
   color: white;
@@ -147,10 +155,36 @@ body.page-about .yubi-main {
   font-weight: bold;
   padding: 4px 8px;
   border-radius: 12px;
-  margin-left: 8px;
   min-width: 18px;
   text-align: center;
   line-height: 1;
+}
+
+.yubi-sidebar__notification-close {
+  background-color: var(--text-color-brown);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 16px;
+  font-weight: bold;
+  line-height: 1;
+  padding: 0;
+  transition: all 0.2s ease;
+}
+
+.yubi-sidebar__notification-close:hover {
+  background-color: #8b6f47;
+  transform: scale(1.1);
+}
+
+.yubi-sidebar__notification-close:active {
+  transform: scale(0.9);
 }
 
 /* ナビゲーションボタン */
@@ -487,10 +521,54 @@ body.page-about .yubi-main {
   line-height: 1.6;
 }
 
+/* Pick Up! スタイル */
+.yubi-card--pickup {
+  position: relative;
+  border: 2px solid var(--heading-color) !important;
+  background: linear-gradient(135deg, #fff 0%, #f8f9fa 100%);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  transform: scale(1.02);
+  padding-top: 34px;
+}
+
+.yubi-pickup-header {
+  position: absolute;
+  top: 8px;
+  left: 12px;
+  color: var(--heading-color);
+  font-weight: 800;
+  font-size: 14px;
+  padding: 5px;
+  margin-bottom: 8px; /* 約束の本文との間隔 */
+}
+
 /* アクションボタン */
 .yubi-actions {
   display: flex;
   gap: 8px;
+}
+
+/* Material Symbols アイコン */
+.material-symbols-outlined {
+  font-variation-settings:
+    'FILL' 0,
+    'wght' 400,
+    'GRAD' 0,
+    'opsz' 24;
+  font-family: 'Material Symbols Outlined';
+  font-weight: normal;
+  font-style: normal;
+  font-size: 18px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-feature-settings: 'liga';
+  font-feature-settings: 'liga';
+  -webkit-font-smoothing: antialiased;
 }
 
 .yubi-action-button {
@@ -746,6 +824,41 @@ body.page-about .yubi-main {
 }
 
 .yubi-button--add:active {
+  transform: scale(0.95);
+}
+
+/* 既読ボタン専用スタイル */
+.yubi-button--mark-read {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  white-space: nowrap;
+  height: 36px;
+  padding: 0 12px;
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: #fff;
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  transition: all 0.2s ease-out;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  position: absolute;
+  right: 15px;
+  z-index: 10;
+  pointer-events: auto;
+}
+
+.yubi-button--mark-read:hover {
+  background-color: rgba(255, 255, 255, 0.3);
+  transform: scale(1.05);
+}
+
+.yubi-button--mark-read:active {
   transform: scale(0.95);
 }
 
@@ -1462,6 +1575,12 @@ body.page-about .yubi-main {
 .yubi-hitokoto-container .yubi-column__header {
   justify-content: center;
   text-align: center;
+  position: relative;
+}
+
+.yubi-hitokoto-container .yubi-column__header span {
+  flex: 1;
+  text-align: center;
 }
 
 .yubi-hitokoto-form-section {
@@ -1530,6 +1649,31 @@ body.page-about .yubi-main {
   cursor: not-allowed;
   box-shadow: 0 2px 0 #999;
 }
+
+.yubi-hitokoto-success-message {
+  margin-top: 15px;
+  padding: 12px 20px;
+  background-color: #d4edda;
+  color: #155724;
+  border: 1px solid #c3e6cb;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  text-align: center;
+  animation: successFadeIn 0.3s ease-in-out;
+}
+
+@keyframes successFadeIn {
+  0% {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 
 .yubi-send-button .icon {
   display: inline-block;
@@ -2024,7 +2168,7 @@ body.page-about .yubi-main {
     max-width: 90vw;
     margin-bottom: 20px;
   }
-
+  
   .yubi-score-plate,
   .score-plate {
     margin: 10px 0;
@@ -2076,6 +2220,7 @@ body.page-about .yubi-main {
     height: 44px;
     font-size: 16px;
     padding: 0 12px;
+    margin-top: 60px; /* ハンバーガーメニューとの重なりを防ぐ */
   }
 
   .yubi-main--pending-evaluations {
@@ -2169,6 +2314,7 @@ body.page-about .yubi-main {
     height: 40px;
     font-size: 14px;
     padding: 0 10px;
+    margin-top: 55px;
   }
 
   .yubi-main--pending-evaluations {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -106,7 +106,10 @@ export class ApiClient {
       error => {
         if (error.response?.status === 401) {
           localStorage.removeItem('authToken');
-          window.location.href = '/';
+          // ログイン画面以外でのみリロード
+          if (window.location.pathname !== '/') {
+            window.location.href = '/';
+          }
         }
         return Promise.reject(error);
       }


### PR DESCRIPTION
## 概要

ちょっと一言で送信されたものが通知がないため、ユーザーからしたらわかりにくい

## 変更点

- サイドバーのちょっと一言の欄に新たにもらった一言が追加されたら通知を表示
- 通知の横に通知削除ボタンを作成、押すと通知が消え、また追加されるまでは非表示
- ちょっと一言で一言を送った時に送信成功メッセージを表示するように変更