### PR TITLE
評価によってりんごの数を増やす機能の実装

### DIFF
--- a/backend/app/controllers/api/promise_evaluations_controller.rb
+++ b/backend/app/controllers/api/promise_evaluations_controller.rb
@@ -10,6 +10,12 @@ class Api::PromiseEvaluationsController < ApplicationController
 
     if evaluation.save
       @promise.update(updated_at: Time.current)
+
+      # 評価が4以上の場合、アップルカウントを増やす
+      if evaluation.rating >= 4
+        increment_apple_count
+      end
+
       render json: evaluation, status: :created
     else
       render json: { errors: evaluation.errors.full_messages }, status: :unprocessable_entity
@@ -20,5 +26,22 @@ class Api::PromiseEvaluationsController < ApplicationController
 
   def set_promise
     @promise = Promise.find(params[:promise_id])
+  end
+
+  def increment_apple_count
+    return unless current_user&.partnership
+
+    partnership = current_user.partnership
+    current_month = Date.current.beginning_of_month
+
+    # 当月のスコアレコードを取得または作成
+    rating_score = partnership.promise_rating_scores.find_or_initialize_by(
+      year_month: current_month
+    )
+
+    # アップルカウントを1増やす
+    rating_score.harvested_apples ||= 0
+    rating_score.harvested_apples += 1
+    rating_score.save
   end
 end


### PR DESCRIPTION
## 概要

評価した約束が4以上であればふたりの記録のりんごの数が１増えるという機能の実装

## 変更点

- promise_evaluations_controller.rbに評価が4以上のカウントを１増やすロジックの追加