### PR TITLE
約束期日のバリデーション

### DIFF
--- a/backend/app/models/promise.rb
+++ b/backend/app/models/promise.rb
@@ -10,6 +10,7 @@ class Promise < ApplicationRecord
 
     validates :content, presence: true
     validates :type, presence: true
+    validate :due_date_cannot_be_in_the_past
 
     # スコープ：ふたりの約束
     scope :our_promises, -> {
@@ -85,6 +86,14 @@ class Promise < ApplicationRecord
     after_validation :log_validation_errors
 
     private
+
+    def due_date_cannot_be_in_the_past
+      return if due_date.blank? # 期日がない場合（our_promise）はスキップ
+
+      if due_date.present? && due_date < Date.today
+        errors.add(:due_date, "は過去の日付を設定できません")
+      end
+    end
 
     def log_validation_errors
       if errors.any?

--- a/frontend/src/components/modals/AddPromiseModal.tsx
+++ b/frontend/src/components/modals/AddPromiseModal.tsx
@@ -24,6 +24,9 @@ const AddPromiseModal = ({
   const [content, setContent] = useState<string>('');
   const [dueDate, setDueDate] = useState<string>('');
 
+  // 今日の日付をYYYY-MM-DD形式で取得
+  const today = new Date().toISOString().split('T')[0];
+
   const isOurPromise = promiseType === 'our_promise';
 
   useEffect(() => {
@@ -121,6 +124,7 @@ const AddPromiseModal = ({
                   value={dueDate}
                   onChange={e => setDueDate(e.target.value)}
                   className="yubi-form-group__input"
+                  min={today}
                 />
               </div>
             )}

--- a/frontend/src/components/modals/EditPromiseModal.tsx
+++ b/frontend/src/components/modals/EditPromiseModal.tsx
@@ -19,6 +19,9 @@ const EditPromiseModal = ({
   const [content, setContent] = useState<string>('');
   const [dueDate, setDueDate] = useState<string>('');
 
+  // 今日の日付をYYYY-MM-DD形式で取得
+  const today = new Date().toISOString().split('T')[0];
+
   useEffect(() => {
     if (promise && isOpen) {
       setContent(promise.content);
@@ -105,6 +108,7 @@ const EditPromiseModal = ({
                 value={dueDate}
                 onChange={e => setDueDate(e.target.value)}
                 className="yubi-form-group__input"
+                min={today}
               />
             </div>
           </div>


### PR DESCRIPTION
## 概要

約束作成時に過去の日付を選択できないように変更

## 変更点

- フロント側の約束作成時のモーダルでmin属性を追加し、過去の日付を選択不可に変更
- バックエンド側でもバリデーションをつけて過去の日付が送信されたらエラーになるように変更