### PR TITLE
無駄なテストの削除

### DIFF
--- a/backend/spec/mailers/evaluation_mailer_spec.rb
+++ b/backend/spec/mailers/evaluation_mailer_spec.rb
@@ -22,12 +22,6 @@ RSpec.describe EvaluationMailer, type: :mailer do
       expect(body_text).to include('evaluate')
       expect(body_text).to include(promise.id.to_s)
     end
-
-    it 'メールを送信できる' do
-      expect {
-        mail.deliver_now
-      }.to change { ActionMailer::Base.deliveries.count }.by(1)
-    end
   end
 
   describe '#due_date_evaluation_email' do

--- a/backend/spec/mailers/monthly_report_mailer_spec.rb
+++ b/backend/spec/mailers/monthly_report_mailer_spec.rb
@@ -41,12 +41,6 @@ RSpec.describe MonthlyReportMailer, type: :mailer do
       body_text = mail.html_part.body.to_s
       expect(body_text).to include(partner.name)
     end
-
-    it 'メールを送信できる' do
-      expect {
-        mail.deliver_now
-      }.to change { ActionMailer::Base.deliveries.count }.by(1)
-    end
   end
 
   describe '.send_monthly_reports' do

--- a/backend/spec/mailers/password_reset_mailer_spec.rb
+++ b/backend/spec/mailers/password_reset_mailer_spec.rb
@@ -25,12 +25,6 @@ RSpec.describe PasswordResetMailer, type: :mailer do
     it 'リセットURLが含まれる' do
       expect(mail.html_part.body.to_s).to include('password-reset')
     end
-
-    it 'メールを送信できる' do
-      expect {
-        mail.deliver_now
-      }.to change { ActionMailer::Base.deliveries.count }.by(1)
-    end
   end
 end
 

--- a/backend/spec/mailers/registration_mailer_spec.rb
+++ b/backend/spec/mailers/registration_mailer_spec.rb
@@ -18,12 +18,6 @@ RSpec.describe RegistrationMailer, type: :mailer do
       body_text = mail.html_part ? mail.html_part.body.to_s : mail.body.to_s
       expect(body_text).to include(user.name)
     end
-
-    it 'メールを送信できる' do
-      expect {
-        mail.deliver_now
-      }.to change { ActionMailer::Base.deliveries.count }.by(1)
-    end
   end
 end
 

--- a/backend/spec/models/invitation_code_spec.rb
+++ b/backend/spec/models/invitation_code_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe InvitationCode, type: :model do
-  describe 'associations' do
-    it { should belong_to(:inviter).class_name('User') }
-  end
-
   describe 'validations' do
     it 'codeが存在すること' do
       invitation_code = create(:invitation_code)

--- a/backend/spec/models/one_word_spec.rb
+++ b/backend/spec/models/one_word_spec.rb
@@ -1,16 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe OneWord, type: :model do
-  describe 'associations' do
-    it { should belong_to(:partnership) }
-    it { should belong_to(:sender).class_name('User') }
-    it { should belong_to(:receiver).class_name('User') }
-  end
-
-  describe 'validations' do
-    it { should validate_presence_of(:content) }
-  end
-
   describe 'scopes' do
     let(:partnership) { create(:partnership) }
     let(:user) { partnership.user }

--- a/backend/spec/models/partnership_spec.rb
+++ b/backend/spec/models/partnership_spec.rb
@@ -1,14 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Partnership, type: :model do
-  describe 'associations' do
-    it { should belong_to(:user) }
-    it { should belong_to(:partner).class_name('User') }
-    it { should have_many(:promises).dependent(:destroy) }
-    it { should have_many(:one_words).dependent(:destroy) }
-    it { should have_many(:promise_rating_scores).dependent(:destroy) }
-  end
-
   describe '#partner_of' do
     let(:user) { create(:user) }
     let(:partner) { create(:user) }

--- a/backend/spec/models/promise_evaluation_spec.rb
+++ b/backend/spec/models/promise_evaluation_spec.rb
@@ -1,11 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe PromiseEvaluation, type: :model do
-  describe 'associations' do
-    it { should belong_to(:promise) }
-    it { should belong_to(:evaluator).class_name('User') }
-  end
-
   describe 'validations' do
     it '有効な評価を作成できる' do
       partnership = create(:partnership)

--- a/backend/spec/models/promise_rating_score_spec.rb
+++ b/backend/spec/models/promise_rating_score_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe PromiseRatingScore, type: :model do
-  describe 'associations' do
-    it { should belong_to(:partnership) }
-  end
-
   describe 'validations' do
     it '有効なレコードを作成できる' do
       score = build(:promise_rating_score)

--- a/backend/spec/models/promise_spec.rb
+++ b/backend/spec/models/promise_spec.rb
@@ -1,17 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Promise, type: :model do
-  describe 'associations' do
-    it { should belong_to(:partnership) }
-    it { should belong_to(:creator).class_name('User') }
-    it { should have_one(:promise_evaluation).dependent(:destroy) }
-    it { should have_many(:promise_histories).dependent(:destroy) }
-  end
-
   describe 'validations' do
-    it { should validate_presence_of(:content) }
-    it { should validate_presence_of(:type) }
-
     context '期日のバリデーション' do
       let(:partnership) { create(:partnership) }
 
@@ -286,12 +276,6 @@ RSpec.describe Promise, type: :model do
       promise.reset_for_next_evaluation
       expect(promise.reload.updated_at).to be > old_updated_at
     end
-
-    it '約束自体は削除されない' do
-      promise_id = promise.id
-      promise.reset_for_next_evaluation
-      expect(Promise.find_by(id: promise_id)).to be_present
-    end
   end
 
   describe '.reset_evaluated_our_promises' do
@@ -316,12 +300,6 @@ RSpec.describe Promise, type: :model do
     it '評価がない約束には影響しない' do
       Promise.reset_evaluated_our_promises
       expect(our_promise_no_eval.reload.promise_evaluation).to be_nil
-    end
-
-    it '約束自体は削除されない' do
-      expect {
-        Promise.reset_evaluated_our_promises
-      }.not_to change(Promise, :count)
     end
 
     it 'ふたりの約束のみが対象' do

--- a/backend/spec/models/user_credential_spec.rb
+++ b/backend/spec/models/user_credential_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe UserCredential, type: :model do
-  describe 'associations' do
-    it { should belong_to(:user) }
-  end
-
   describe 'has_secure_password' do
     let(:user) { create(:user) }
     let(:credential) { user.user_credential }

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -1,14 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  describe 'associations' do
-    it { should have_one(:user_credential).dependent(:destroy) }
-    it { should have_many(:partnerships_as_user).dependent(:destroy) }
-    it { should have_many(:partnerships_as_partner).dependent(:destroy) }
-    it { should have_many(:created_promises).dependent(:destroy) }
-    it { should have_many(:evaluated_promises).dependent(:destroy) }
-  end
-
   describe 'validations' do
     it { should validate_presence_of(:email) }
     it { should validate_presence_of(:name) }


### PR DESCRIPTION
## 概要

過剰だったり無駄なテストの削除

## 変更点

- メール関係の送信できるかのテストは起こり得ないので削除
- アソシエーション関係のRailsの機能をテストする必要はなかったので削除